### PR TITLE
perf: Moving iconList into a component to memoize it

### DIFF
--- a/src/components/left-panel/IconList.tsx
+++ b/src/components/left-panel/IconList.tsx
@@ -1,0 +1,30 @@
+import { memo } from "react";
+import { IconProps } from "@/App";
+import { Button } from "@/components/ui/button.tsx";
+import { icons, isLucideIcon } from '@/lib/icons.ts';
+
+
+type Props = {
+  iconSearch: string;
+  setIcon: (icon: Partial<IconProps>) => void;
+}
+
+const IconList = ({ iconSearch, setIcon }: Props) => {
+  return Object.entries(icons)
+    .filter(([key]) => key.toLowerCase().includes(iconSearch.toLowerCase()))
+    .map(([key, IconComponent]) => (
+      <Button
+        key={key}
+        variant="outline"
+        onClick={() => {
+          if (!isLucideIcon(key)) return;
+          setIcon({ iconName: key });
+        }}
+        className="rounded-md aspect-square w-full h-auto [&_svg]:size-6"
+      >
+        <IconComponent />
+      </Button>
+    ));
+};
+
+export default memo(IconList, (prevProps, props) => prevProps.iconSearch === props.iconSearch);

--- a/src/components/left-panel/Sidebar.tsx
+++ b/src/components/left-panel/Sidebar.tsx
@@ -5,7 +5,6 @@ import {
   SidebarGroupContent,
   SidebarMenu,
 } from "@/components/ui/sidebar";
-import { icons, isLucideIcon } from "@/lib/icons";
 import { Input } from "../ui/input";
 import { useContext, useState } from "react";
 import { IconContext } from "@/App";
@@ -13,6 +12,7 @@ import { Button } from "../ui/button";
 import { Shuffle } from "lucide-react";
 import { CollapsibleComponent } from "./Collapsible";
 import { getRandomIcon } from "@/lib/utils";
+import IconList from "./IconList";
 
 export function LeftSidebar() {
   const { icon, setIcon } = useContext(IconContext);
@@ -48,23 +48,7 @@ export function LeftSidebar() {
           <CollapsibleComponent title="All icons">
             <SidebarGroupContent className="mt-3">
               <SidebarMenu className="grid grid-cols-[repeat(4,1fr)] gap-2">
-                {Object.entries(icons)
-                  .filter(([key]) =>
-                    key.toLowerCase().includes(iconSearch.toLowerCase())
-                  )
-                  .map(([key, IconComponent]) => (
-                    <Button
-                      key={key}
-                      variant="outline"
-                      onClick={() => {
-                        if (!isLucideIcon(key)) return;
-                        setIcon({ ...icon, iconName: key });
-                      }}
-                      className="rounded-md aspect-square w-full h-auto [&_svg]:size-6"
-                    >
-                      <IconComponent />
-                    </Button>
-                  ))}
+                <IconList iconSearch={iconSearch} setIcon={(partialIcon) => setIcon({...icon, ...partialIcon})} />
               </SidebarMenu>
             </SidebarGroupContent>
           </CollapsibleComponent>


### PR DESCRIPTION
It enhances page performance by preventing unnecessary re-renders of thousands of icons

## BEFORE
https://github.com/user-attachments/assets/22736b0e-6899-447a-8402-cfae9a9aa336


## AFTER:
https://github.com/user-attachments/assets/4962591c-6281-4a2b-bac2-39a2d93889e5

