### PR TITLE
fix: revoke blob URI on donwload

### DIFF
--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -1,7 +1,12 @@
 export const downloadSvg = (svgElement: SVGSVGElement) => {
   const svg = svgElement.outerHTML;
+  const blob = new Blob([svg], { type: "image/svg+xml" });
+  const url = URL.createObjectURL(blob);
+
   const a = document.createElement("a");
-  a.href = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
+  a.href = url;
   a.download = "favicon.svg";
   a.click();
+  // GC won't collect it otherwise
+  URL.revokeObjectURL(url);
 };


### PR DESCRIPTION
Blob URIs create pointers protected from GC, so let's make sure we invalidate it after we download it. See https://stackoverflow.com/a/49346614